### PR TITLE
fixes für anzeigebugs

### DIFF
--- a/DarkTip.js
+++ b/DarkTip.js
@@ -952,7 +952,7 @@ window.DarkTip = {
 				'viewport': this.jq(window),
 				'effect'  : false
 			},
-			'hide' :'mouseout',
+			'hide' :'mouseleave',
 			'style': {
 				'width'  : width+'px',
 				'classes': ('ui-tooltip-cluetip darktip-tooltip ' + cssclass)


### PR DESCRIPTION
Hi,

ich verwende die Darktips bei einem Wow-Projekt von mir. Da fiel mir auf, dass sie bei meinem Itemlinks scheinbar unkontrolliert anfingen kurz zu flackern bzw. auch einfach wieder verschwanden.
Konkret scheint das bei allen Fällen von verschachtelten Elementen gewesen zu sein in dem ein Elternelement einen Darktip hatte.
z.B.: < a href="http://eu.battle.net/wow/de/item/78000">< img src="http://eu...jpg" />< /a>

Der Fehler enstand durch die Nutzung der jQuery-Events mouseover und mouseout, welche ständig feuern, wenn ein Kindselement (mit der Maus) überfahren wird. Besser ist hier die nutzung von mouseenter und mouseleave, da sie echt nur am Entsprechendem element feuern. (siehe demo bei: http://api.jquery.com/mouseleave/)

Ich habe dabei noch ein paar Kleinigkeiten optimiert, was das ganze hoffentlich noch einen Tick fixer und stabiler macht. Schau es dir bei bitte Gelegenheit einfach mal an, danke.

mfg exo

btw.. Arrays lassen sich in JS per concat() mergen/verknüpfen. ;) (siehe startUp( ))
